### PR TITLE
Add info field when rebuilding observation from dict

### DIFF
--- a/agents/base_agent.py
+++ b/agents/base_agent.py
@@ -68,7 +68,7 @@ class BaseAgent:
         """
         _, observation_dict, _ = self.communicate(action)
         if observation_dict:
-            return Observation(GameState.from_dict (observation_dict["state"]), observation_dict["reward"], observation_dict["end"],{})
+            return Observation(GameState.from_dict (observation_dict["state"]), observation_dict["reward"], observation_dict["end"], observation_dict["info"])
         else:
             return None
     


### PR DESCRIPTION
Fixed bug in the base_agent which was not including the 'info' field when rebuilding Observation from dict after recieving the message.