### PR TITLE
use AgentStatus for stats

### DIFF
--- a/agents/attackers/llm_qa/llm_action_planner.py
+++ b/agents/attackers/llm_qa/llm_action_planner.py
@@ -31,7 +31,7 @@ sys.path.append(
 )
 sys.path.append(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
 
-from env.game_components import ActionType, Observation
+from AIDojoCoordinator.game_components import Action, ActionType, GameState, Observation, IP, Network
 from llm_utils import create_action_from_response, create_status_from_state
 
 class ConfigLoader:
@@ -145,7 +145,7 @@ class LLMActionPlanner:
         Q1 = self.config['questions'][0]['text']
         Q4 = self.config['questions'][3]['text']
         COT_PROMPT = self.config['prompts']['COT_PROMPT']
-        print(memory_buf)
+        #print(memory_buf)
         memory_prompt = self.create_mem_prompt(memory_buf)
         messages = [
             {"role": "user", "content": self.instructions},
@@ -153,7 +153,7 @@ class LLMActionPlanner:
             {"role": "user", "content": memory_prompt},
             {"role": "user", "content": Q1},
         ]
-        print(messages)
+        #print(messages)
         self.logger.info(f"Text sent to the LLM: {messages}")
         response = self.openai_query(messages, max_tokens=1024)
         self.logger.info(f"(Stage 1) Response from LLM: {response}")
@@ -171,4 +171,5 @@ class LLMActionPlanner:
 
         response = self.openai_query(messages, max_tokens=80, fmt={"type": "json_object"})
         self.logger.info(f"(Stage 2) Response from LLM: {response}")
+        print(f"(Stage 2) Response from LLM: {response}")
         return self.parse_response(response, observation.state) 

--- a/agents/attackers/llm_qa/llm_agent_qa.py
+++ b/agents/attackers/llm_qa/llm_agent_qa.py
@@ -22,8 +22,7 @@ sys.path.append(
     path.dirname(path.dirname(path.dirname(path.dirname(path.abspath(__file__)))))
 )
 
-from AIDojoCoordinator.game_components import ActionType, Action, IP, Data, Network, Service
-
+from AIDojoCoordinator.game_components import AgentStatus
 # This is used so the agent can see the BaseAgent
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 from base_agent import BaseAgent
@@ -168,7 +167,7 @@ if __name__ == "__main__":
                 else:
                     evaluations.append(3)
             else:
-                print("Invalid action")
+                print("Invalid action: ")
                 evaluations.append(0)
 
             try:
@@ -180,6 +179,8 @@ if __name__ == "__main__":
                             "not valid based on your status."
                         )
                     )
+                    print("not valid based on your status.")
+
                 else:
                     # This is based on the assumption that more valid actions in the state are better/more helpful.
                     # But we could a manual evaluation based on the prior knowledge and weight the different components.
@@ -192,6 +193,7 @@ if __name__ == "__main__":
                                 "helpful."
                             )
                         )
+                        print("Helpful")
                     else:
                         memories.append(
                             (
@@ -200,7 +202,7 @@ if __name__ == "__main__":
                                 "not helpful."
                             )
                         )
-
+                        print("Not Helpful")
                     # If the action was repeated count it
                     if action in actions_took_in_episode:
                         repeated_actions += 1
@@ -214,6 +216,7 @@ if __name__ == "__main__":
                                 response_dict["parameters"]),
                                 "badly formated."
                 )
+                print("badly formated")
             
            # logger.info(f"Iteration: {i} JSON: {is_json_ok} Valid: {is_valid} Good: {good_action}")
             logger.info(f"Iteration: {i} Valid: {is_valid} Good: {good_action}")
@@ -225,7 +228,7 @@ if __name__ == "__main__":
                     # TODO: Fix this
                     reason = observation.info
                 else:
-                    reason = {"end_reason": "max_iterations"}
+                    reason = {"end_reason": AgentStatus.TimeoutReached }
 
                 win = 0
                 # is_detected if boolean
@@ -234,16 +237,16 @@ if __name__ == "__main__":
                 steps = i
                 epi_last_reward = observation.reward
                 num_actions_repeated += [repeated_actions]
-                if "goal_reached" in reason["end_reason"]:
+                if AgentStatus.Success == reason["end_reason"]:
                     wins += 1
                     num_win_steps += [steps]
                     type_of_end = "win"
                     evaluations[-1] = 10
-                elif "detected" in reason["end_reason"]:
+                elif AgentStatus.Fail == reason["end_reason"]:
                     detected += 1
                     num_detected_steps += [steps]
                     type_of_end = "detection"
-                elif "max_iterations" in reason["end_reason"]:
+                elif AgentStatus.TimeoutReached == reason["end_reason"]:
                     # TODO: Fix this
                     reach_max_steps += 1
                     type_of_end = "max_iterations"


### PR DESCRIPTION
# Description

Just some minimal changes for adapt the LLM_QA stats to the Netsecgame integrated with CYST

Fixes # 
Old version used the string 'if "goal_reached" in reason["end_reason"]:  ` now it uses the AgentStatus object

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [X ] using small scenario and gtp4o-mini during 4 episodes, stats are now OK



# Checklist:

- [ X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
