### PR TITLE
Add --use_reasoning flag to handle <think> ... </think> model outputs

### DIFF
--- a/agents/attackers/llm_qa/llm_agent_qa.py
+++ b/agents/attackers/llm_qa/llm_agent_qa.py
@@ -77,7 +77,13 @@ if __name__ == "__main__":
         type=str, 
         default="http://127.0.0.1:11434/v1/"
         )
-    
+
+    parser.add_argument(
+        "--use_reasoning",
+        action="store_true",
+        help="Required for models that output reasoning using <think>...</think>."
+    )
+
     parser.add_argument(
         "--mlflow_tracking_uri",
         type=str,
@@ -188,7 +194,8 @@ if __name__ == "__main__":
             model_name=args.llm,
             goal=observation.info["goal_description"],
             memory_len=args.memory_buffer,
-            api_url=args.api_url
+            api_url=args.api_url,
+            use_reasoning=args.use_reasoning
         )
         print(observation)
         for i in range(num_iterations):


### PR DESCRIPTION
# Description

This PR adds support for a `--use_reasoning` flag that handles model outputs containing intermediate reasoning in `<think>...</think>` blocks.

When enabled, this feature strips the reasoning section and returns only the final actionable output. This is particularly useful for working with local LLMs like DeepSeek, which tend to include internal thought processes in their responses.


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix
- [ ] Breaking change
- [ ] This change requires a documentation update

# How Has This Been Tested?

To ensure the `--use_reasoning` flag reliably strips out internal reasoning and yields valid commands:

- [x] **Deployed the llm_agent_qa** with a local LLM (DeepSeek‑LLM‑R1:8B) in the NetSecGame environment  
- [x] **Ran baseline sessions** without the flag and confirmed malformed outputs when `<think>…</think>` blocks were present  
- [x] **Enabled the flag** and observed an increased command success rate thanks to correctly filtered outputs 


All tests confirm the flag effectively transforms commands with reasoning blocks into clean, actionable instructions across all supported LLMs.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
